### PR TITLE
Fix close-external-prs workflow incorrectly closing internal PRs

### DIFF
--- a/.github/workflows/close-external-prs.yml
+++ b/.github/workflows/close-external-prs.yml
@@ -17,24 +17,30 @@ jobs:
         with:
           script: |
             const author = context.payload.pull_request.user.login;
+            const association = context.payload.pull_request.author_association;
 
-            try {
-              // Check if the author is a member of the Shopify organization
-              await github.rest.orgs.checkMembershipForUser({
-                org: 'Shopify',
-                username: author
-              });
+            // author_association is unreliable when org membership is private
+            // (returns CONTRIBUTOR instead of MEMBER), so also check the
+            // repo permission level which works regardless of visibility
+            const trustedAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            let isTrusted = trustedAssociations.includes(association);
 
-              console.log(`${author} is a Shopify member`);
-              core.setOutput('is-shopify', 'true');
-            } catch (error) {
-              if (error && error.status === 404) {
-                console.log(`${author} is not a Shopify member`);
-              } else {
-                console.log(`Error checking Shopify membership for ${author}: ${error}`);
+            if (!isTrusted) {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: author,
+                });
+                isTrusted = ['write', 'admin'].includes(data.permission);
+                console.log(`${author} repo permission: ${data.permission}`);
+              } catch (error) {
+                console.log(`Permission check failed for ${author}: ${error.message}`);
               }
-              core.setOutput('is-shopify', 'false');
             }
+
+            console.log(`${author} author_association: ${association}, trusted: ${isTrusted}`);
+            core.setOutput('is-shopify', isTrusted ? 'true' : 'false');
 
       - name: Close PR and comment
         if: steps.check-author.outputs.is-shopify == 'false'
@@ -50,11 +56,11 @@ jobs:
               issue_number: prNumber,
               body: `Thanks for your interest. This repository does not accept contributions, so we've closed this PR.
 
-To report a bug, request a feature, or share feedback, please post in the [Shopify dev community forums](https://community.shopify.dev/c/shopify-cli-libraries/14)
+To report a bug, request a feature, or share feedback, please post in the [Shopify dev community forums](https://community.shopify.dev/new-topic?title=[Feedback%20for%20python%20package]&category=shopify-cli-libraries&tags=python-library&domain=Python%20Library)
 
 We triage in the forums, not in this repo. PRs and issues here are closed without review.
 
-For more details see [CONTRIBUTING.md](https://github.com/Shopify/shopify-app-python?tab=contributing-ov-file).`
+For more details see [CONTRIBUTING.md](https://github.com/Shopify/shopify-app-python/blob/main/CONTRIBUTING.md).`
             });
 
             // Close the PR


### PR DESCRIPTION
## Summary
- The `orgs.checkMembershipForUser` API requires `read:org` scope which the default `GITHUB_TOKEN` doesn't have, causing all PRs to be incorrectly treated as external
- Switch to using `author_association` from the webhook payload (checks for `MEMBER`, `OWNER`, `COLLABORATOR`) with a fallback `getCollaboratorPermissionLevel` repo-level check
- Update forum link to use new-topic format with Python-specific tags

## Test plan
- [ ] Open a test PR from a Shopify member account and verify it is not closed
- [ ] Verify the workflow matches the already-deployed fix in [shopify-app-php](https://github.com/Shopify/shopify-app-php)

🤖 Generated with [Claude Code](https://claude.com/claude-code)