### PR TITLE
Create a GitHub release when publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,3 +93,26 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         # No credentials needed - uses OIDC trusted publishing
+
+  github-release:
+    name: Create GitHub release
+    needs: [check-version, publish]
+    if: needs.check-version.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ needs.check-version.outputs.version }}
+        run: |
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping."
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --generate-notes
+          fi


### PR DESCRIPTION
## What
Adds a `github-release` job to the publish workflow that tags `v<version>` and creates a GitHub release after a successful PyPI publish.

## Why
The workflow publishes to PyPI but never tags the repo or creates a GitHub release, so this repo shows no releases even though the package is live on PyPI (`shopifyapp` 1.0.0). That's inconsistent with `shopify-app-php`, whose publish workflow already creates a release. This mirrors that behavior.

## Notes
- Runs only after a successful `publish`, and skips if the release/tag already exists (safe to re-run).
- Uses the same `v<version>` tag + `--generate-notes` pattern as the PHP package.
- Takes effect on the next release. The existing `v1.0.0` still needs a one-time backfill (`gh release create v1.0.0`) since it already published before this landed.