### PR TITLE
fix: handle non-integer Retry-After values in GraphQL retry

### DIFF
--- a/shopify_app/graphql/admin_graphql.py
+++ b/shopify_app/graphql/admin_graphql.py
@@ -395,7 +395,11 @@ def _handle_429_retry_sync(
                 res=res,
             )
         )
-        time.sleep(int(retry_after))
+        try:
+            delay = float(retry_after)
+        except (TypeError, ValueError):
+            delay = 1.0
+        time.sleep(delay)
         return (True, False, None)
 
     if status_code == 429 and attempt == max_retries:
@@ -451,7 +455,11 @@ async def _handle_429_retry_async(
                 res=res,
             )
         )
-        await asyncio.sleep(int(retry_after))
+        try:
+            delay = float(retry_after)
+        except (TypeError, ValueError):
+            delay = 1.0
+        await asyncio.sleep(delay)
         return (True, False, None)
 
     if status_code == 429 and attempt == max_retries:


### PR DESCRIPTION
## Summary
Fixes #18 — `int(retry_after)` raises `ValueError` when `Retry-After` header is a decimal (e.g., `"2.0"`) or HTTP-date. This PR uses `float()` with a fallback to 1.0, covering both integer and decimal values. If parsing fails, it defaults to 1 second.

## Changes
- `_handle_429_retry_sync`: replaced `int(retry_after)` with `float()` + try/except
- `_handle_429_retry_async`: same for async sleep

## Testing
- Verified with `float("2.0")` and `float("2")` both work.
- Verified fallback when header is missing or invalid.

## Related
- Issue #18 (the `Retry-After` parsing bug)
- Issue #17 (header lookup bug) — this PR does not address that; it only fixes the parsing error that would be exposed once #17 is fixed.

Closes #18